### PR TITLE
feat: add cancellable before-events for resource members

### DIFF
--- a/lib/Db/Resource.php
+++ b/lib/Db/Resource.php
@@ -29,6 +29,10 @@ abstract class Resource extends Entity implements JsonSerializable, TableSeriali
 
 	abstract public function getType(): string;
 
+    public function getOrganizationFolderId(): int {
+        return $this->organizationFolderId;
+    }
+
 	public function limitedJsonSerialize(): array {
 		return [
 			'id' => $this->id,

--- a/lib/Db/ResourceMember.php
+++ b/lib/Db/ResourceMember.php
@@ -54,6 +54,10 @@ class ResourceMember extends Entity implements JsonSerializable, TableSerializab
 		return $this->principal?->getId();
 	}
 
+    public function getResourceId(): int {
+        return $this->resourceId;
+    }
+
 	public function setPermissionLevel(int $permissionLevel) {
 		if($permissionLevel >= 1 && $permissionLevel <= 2) {
 			if ($permissionLevel === $this->permissionLevel) {

--- a/lib/Errors/Api/ActionCancelled.php
+++ b/lib/Errors/Api/ActionCancelled.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace OCA\OrganizationFolders\Errors\Api;
+
+use OCP\AppFramework\Http;
+
+class ActionCancelled extends ApiError {
+	public function __construct(
+		string $message,
+		int $httpCode = Http::STATUS_CONFLICT,
+	) {
+		parent::__construct(
+			message: $message,
+			l10nMessage: $message,
+			httpCode: $httpCode,
+		);
+	}
+}
+

--- a/lib/Events/BeforeResourceMemberCreatedEvent.php
+++ b/lib/Events/BeforeResourceMemberCreatedEvent.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\OrganizationFolders\Events;
+
+class BeforeResourceMemberCreatedEvent extends ResourceMemberEvent {
+}

--- a/lib/Events/BeforeResourceMemberDeletedEvent.php
+++ b/lib/Events/BeforeResourceMemberDeletedEvent.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\OrganizationFolders\Events;
+
+class BeforeResourceMemberDeletedEvent extends ResourceMemberEvent {
+}

--- a/lib/Events/BeforeResourceMemberUpdatedEvent.php
+++ b/lib/Events/BeforeResourceMemberUpdatedEvent.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\OrganizationFolders\Events;
+
+use OCA\OrganizationFolders\Db\Resource;
+use OCA\OrganizationFolders\Db\ResourceMember;
+use OCA\OrganizationFolders\Enum\ResourceMemberPermissionLevel;
+use OCA\OrganizationFolders\Model\Principal;
+
+class BeforeResourceMemberUpdatedEvent extends ResourceMemberEvent {
+    public function __construct(
+        ResourceMember $member,
+        Resource $resource,
+        ?string $actorUid = null,
+        public readonly ?ResourceMemberPermissionLevel $newPermissionLevel,
+        public readonly ?Principal $newPrincipal,
+    ) {
+        parent::__construct($member, $resource, $actorUid);
+    }
+
+    public function getNewPrincipalType(): ?int {
+        return $this->newPrincipal?->getType()->value;
+    }
+
+    public function getNewPrincipalId(): ?string {
+        return $this->newPrincipal?->getId();
+    }
+}

--- a/lib/Events/CancellableEvent.php
+++ b/lib/Events/CancellableEvent.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\OrganizationFolders\Events;
+
+use OCP\EventDispatcher\Event;
+
+abstract class CancellableEvent extends Event {
+    private bool $cancelled;
+    private ?string $errorMessage;
+
+    public function __construct() {
+        parent::__construct();
+        $this->cancelled = false;
+        $this->errorMessage = null;
+    }
+
+    /**
+     * Cancel the operation with an optional error message that will be surfaced
+     * to the frontend. Also stops further propagation.
+     */
+    public function cancel(?string $message = null): void {
+        $this->cancelled = true;
+        $this->errorMessage = $message;
+        $this->stopPropagation();
+    }
+
+    public function isCancelled(): bool {
+        return $this->cancelled;
+    }
+
+    public function getErrorMessage(): ?string {
+        return $this->errorMessage;
+    }
+}

--- a/lib/Events/ResourceMemberEvent.php
+++ b/lib/Events/ResourceMemberEvent.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\OrganizationFolders\Events;
+
+use OCA\OrganizationFolders\Db\Resource;
+use OCA\OrganizationFolders\Db\ResourceMember;
+
+abstract class ResourceMemberEvent extends CancellableEvent {
+    public function __construct(
+        public readonly ResourceMember $member,
+        public readonly Resource       $resource,
+        public readonly ?string        $actorUid = null,
+    ) {
+        parent::__construct();
+    }
+
+    public function getPrincipalId(): string {
+        return $this->member->getPrincipalId();
+    }
+
+    public function getPrincipalType(): int {
+        return $this->member->getPrincipalType();
+    }
+
+    public function getOrganizationFolderId(): int {
+        return $this->resource->getOrganizationFolderId();
+    }
+}


### PR DESCRIPTION
- Introduces `beforeCreate`, `beforeUpdate`, and `beforeDelete` lifecycle events for ResourceMember
- Events are cancellable, allowing listeners to prevent the action and halt further propagation